### PR TITLE
Refactor: Improve installer script logic and execution order

### DIFF
--- a/installer/core/main.sh
+++ b/installer/core/main.sh
@@ -72,30 +72,64 @@ main() {
 
 run_module() {
   local module_name="$1"
+  local module_path="installer/modules/$module_name"
   local found_script=0
-  for script in install.sh checks.sh configure.sh security.sh backups.sh deploy.sh; do
-    if [ -f "installer/modules/$module_name/$script" ]; then
-      found_script=1
-      bash "installer/modules/$module_name/$script"
-      if [ $? -ne 0 ]; then
-        log_error "El script $script falló en el módulo $module_name."
-        exit 1
-      fi
+
+  if [ ! -d "$module_path" ]; then
+    log_warning "Directorio del módulo $module_name no encontrado en $module_path."
+    return
+  fi
+
+  local script_files=()
+  while IFS= read -r script_file; do
+    script_files+=("$script_file")
+  done < <(find "$module_path" -maxdepth 1 -name "*.sh" -type f -printf "%f\n" | sort)
+
+  for script in "${script_files[@]}"; do
+    if [ "$module_name" == "03_frontend" ] && [ "$script" == "build.sh" ]; then
+      continue # Excluir build.sh para el módulo 03_frontend
+    fi
+
+    local script_path="$module_path/$script"
+    log_info "Ejecutando script: $script_path"
+    found_script=1
+    bash "$script_path"
+    if [ $? -ne 0 ]; then
+      log_error "El script $script_path falló en el módulo $module_name."
+      exit 1
     fi
   done
+
   if [[ $found_script -eq 0 ]]; then
-    log_warning "No se encontraron scripts para el módulo $module_name."
+    if [ "$module_name" == "03_frontend" ]; then
+      # No advertir si solo era build.sh el único script, ya que se maneja por separado
+      local only_build_sh=1
+      for s in "${script_files[@]}"; do
+        if [ "$s" != "build.sh" ]; then
+          only_build_sh=0
+          break
+        fi
+      done
+      if [ $only_build_sh -eq 0 ]; then
+         log_warning "No se encontraron scripts aplicables (excluyendo build.sh) para el módulo $module_name en $module_path."
+      fi
+    else
+      log_warning "No se encontraron scripts .sh para el módulo $module_name en $module_path."
+    fi
   fi
 }
 run_prerequisites() { run_module "00_prerequisites"; }
 run_database()      { run_module "01_database"; }
 run_backend()       { run_module "02_backend"; }
 run_frontend() {
-  if [ -f "installer/modules/03_frontend/build.sh" ]; then
-    bash installer/modules/03_frontend/build.sh || handle_error "El build.sh falló para frontend" 1
+  local build_script_path="installer/modules/03_frontend/build.sh"
+  if [ -f "$build_script_path" ]; then
+    log_info "Ejecutando script de build: $build_script_path"
+    bash "$build_script_path" || handle_error "El script $build_script_path falló." 1
   else
-    log_warning "No se encontró build.sh para 03_frontend."
+    log_warning "No se encontró $build_script_path para 03_frontend."
   fi
+  run_module "03_frontend"
 }
 run_webserver()     { run_module "04_webserver"; }
 


### PR DESCRIPTION
This commit introduces several improvements to the main installer script (`installer/core/main.sh`) and the module script execution process:

1.  **Enhanced `run_module` function:**
    *   The `run_module` function in `main.sh` now dynamically discovers all `*.sh` files within each module's directory (e.g., `installer/modules/<module_name>/*.sh`).
    *   It executes these scripts in alphabetical order, which, combined with script renaming (see below), provides explicit control over the execution sequence.
    *   Logging for script execution has been maintained.
    *   Error handling remains in place: if any script fails, the installer will log an error and exit.

2.  **Ordered Script Execution via Renaming:**
    *   Scripts within all module directories (under `installer/modules/`) have been renamed with numeric prefixes (e.g., `10_install.sh`, `20_settings.sh`, `30_configure.sh`, `41_celery.sh`, etc.).
    *   This change ensures a deterministic and logical execution order for all scripts within a module, addressing potential issues with alphabetical ordering of functionally dependent scripts.
    *   This makes the installation process more robust and easier to manage.

3.  **Corrected `run_frontend` Logic:**
    *   The `run_frontend` function now correctly executes the `03_frontend/build.sh` script first.
    *   Subsequently, it calls `run_module "03_frontend"` to execute all other standard lifecycle scripts (e.g., `10_install.sh`, `30_configure.sh`) in that module.
    *   The `run_module` function correctly excludes `build.sh` when called for `03_frontend` to prevent duplicate execution.

4.  **Comprehensive Script Usage:**
    *   These changes ensure that all `.sh` files present in the module directories are now used in the installation process, addressing the requirement that all existing files contribute as intended. Previously, only a fixed list of script names was executed.

5.  **Verification Mechanisms:**
    *   The installer continues to support module-specific `checks.sh` scripts (now e.g. `70_checks.sh`) and global integration/validation tests located in `tests/integration/` and `tests/validation/`.

These modifications make the installation process more robust, predictable, and maintainable, ensuring all components are installed and configured in the correct sequence.